### PR TITLE
Update Istio charts 1.22.8+6-tlsnist-preview

### DIFF
--- a/charts/istio/1.22.8+tetrate6/gateways/istio-egress/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/gateways/istio-egress/values.yaml
@@ -153,7 +153,7 @@ defaults:
     hub: addon-containers.istio.tetratelabs.com
 
     # Default tag for Istio images.
-    tag: 1.22.8-tetrate6
+    tag: 1.22.8-tetrate6-tlsnist-preview
 
     # Specify image pull policy if default behavior isn't desired.
     # Default behavior: latest images will be Always else IfNotPresent.

--- a/charts/istio/1.22.8+tetrate6/gateways/istio-ingress/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/gateways/istio-ingress/values.yaml
@@ -165,7 +165,7 @@ defaults:
     hub: addon-containers.istio.tetratelabs.com
 
     # Default tag for Istio images.
-    tag: 1.22.8-tetrate6
+    tag: 1.22.8-tetrate6-tlsnist-preview
 
     # Variant of the image to use.
     # Currently supported are: [debug, distroless]

--- a/charts/istio/1.22.8+tetrate6/istio-cni/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/istio-cni/values.yaml
@@ -110,7 +110,7 @@ defaults:
     hub: addon-containers.istio.tetratelabs.com
 
     # Default tag for Istio images.
-    tag: 1.22.8-tetrate6
+    tag: 1.22.8-tetrate6-tlsnist-preview
 
     # Variant of the image to use.
     # Currently supported are: [debug, distroless]

--- a/charts/istio/1.22.8+tetrate6/istio-control/istio-discovery/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/istio-control/istio-discovery/values.yaml
@@ -234,7 +234,7 @@ defaults:
     # Dev builds from prow are on gcr.io
     hub: addon-containers.istio.tetratelabs.com
     # Default tag for Istio images.
-    tag: 1.22.8-tetrate6
+    tag: 1.22.8-tetrate6-tlsnist-preview
     # Variant of the image to use.
     # Currently supported are: [debug, distroless]
     variant: ""

--- a/charts/istio/1.22.8+tetrate6/istio-operator/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/istio-operator/values.yaml
@@ -1,6 +1,6 @@
 defaults:
   hub: addon-containers.istio.tetratelabs.com
-  tag: 1.22.8-tetrate6
+  tag: 1.22.8-tetrate6-tlsnist-preview
 
   # ImagePullSecrets for operator ServiceAccount, list of secrets in the same namespace
   # used to pull operator image. Must be set for any cluster configured with private docker registry.

--- a/charts/istio/1.22.8+tetrate6/istiod-remote/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/istiod-remote/values.yaml
@@ -197,7 +197,7 @@ defaults:
     # Dev builds from prow are on gcr.io
     hub: addon-containers.istio.tetratelabs.com
     # Default tag for Istio images.
-    tag: 1.22.8-tetrate6
+    tag: 1.22.8-tetrate6-tlsnist-preview
     # Variant of the image to use.
     # Currently supported are: [debug, distroless]
     variant: ""

--- a/charts/istio/1.22.8+tetrate6/ztunnel/values.yaml
+++ b/charts/istio/1.22.8+tetrate6/ztunnel/values.yaml
@@ -2,7 +2,7 @@ defaults:
   # Hub to pull from. Image will be `Hub/Image:Tag-Variant`
   hub: addon-containers.istio.tetratelabs.com
   # Tag to pull from. Image will be `Hub/Image:Tag-Variant`
-  tag: 1.22.8-tetrate6
+  tag: 1.22.8-tetrate6-tlsnist-preview
   # Variant to pull. Options are "debug" or "distroless". Unset will use the default for the given version.
   variant: ""
 


### PR DESCRIPTION
This updates Istio charts 1.22.8+6-tlsnist-preview .