### PR TITLE
add onboarding operator chart

### DIFF
--- a/charts/addons/onboarding-operator/.helmignore
+++ b/charts/addons/onboarding-operator/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/addons/onboarding-operator/Chart.yaml
+++ b/charts/addons/onboarding-operator/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+version: 0.1.0-rc.1
+appVersion: 0.1.0-onboarding-rc.1
+description: Helm chart for the Onboarding Operator
+name: onboarding-operator
+icon: https://docs.tetrate.io/logos/tetrate.svg

--- a/charts/addons/onboarding-operator/README.md
+++ b/charts/addons/onboarding-operator/README.md
@@ -1,0 +1,26 @@
+# onboarding-operator
+
+![Version: 0.1.0-rc.1](https://img.shields.io/badge/Version-0.1.0--rc.1-informational?style=flat-square)
+![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![AppVersion: 0.1.0-onboarding-rc.1](https://img.shields.io/badge/AppVersion-0.1.0--onboarding--rc.1-informational?style=flat-square)
+
+
+Helm chart for the Workload Onboarding Operator. It is used to onboard EC2 VMs and ECS tasks to an Istio service mesh installed on an EKS cluster.
+
+## Values
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| image.repository | string | `"addon-containers.istio.tetratelabs.com"` | Image repository from where download the onboarding images |
+| image.tag | string | `"0.1.0-onboarding-rc.1"` | Onboarding image tag to be used |
+| image.pullSecret | list | `[]` | Image pull secret to be used to pull the onboarding images |
+| image.pullPolicy | string | `"IfNotPresent"` |  |
+| repository.onboardingPackageIstioSidecar.tag | string | `"1.24.3-4fcf99438c"` | Istio sidecar tag to be used for the onboarding workloads |
+| onboarding.endpoint.host | string | `"onboarding-endpoint.example"` | Hostname for the onboarding endpoint |
+| onboarding.endpoint.tlsSecretName | string | `"onboarding-endpoint-tls-cert"` | Secret name for the onboarding endpoint TLS certificate |
+
+To view all support configuration options and documentation, run:
+
+```
+helm show values tetratelabs/onboarding-operator
+```

--- a/charts/addons/onboarding-operator/templates/_helper.tpl
+++ b/charts/addons/onboarding-operator/templates/_helper.tpl
@@ -1,0 +1,17 @@
+{{/*
+Labels that should be applied to ALL resources.
+*/}}
+{{- define "onboarding.labels" -}}
+{{- if .Release.Service -}}
+app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+{{- end }}
+{{- if .Release.Name }}
+app.kubernetes.io/instance: {{ .Release.Name | quote }}
+{{- end }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+{{- if and .Chart.Name .Chart.Version }}
+helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+{{- end }}
+{{- end -}}

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/config/gateway.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/config/gateway.yaml
@@ -1,0 +1,54 @@
+
+{{- $component := .Values.gateway -}}
+apiVersion: networking.istio.io/v1
+kind: Gateway
+metadata:
+  name: {{ $component.name }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    topology.istio.io/network: {{ $component.network }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  selector:
+    app: {{ $component.name }}
+  servers:
+  - hosts:
+    - istiod.{{ .Release.Namespace }}.svc
+    port:
+      name: tls-istiod
+      number: 15443
+      protocol: TLS
+    tls:
+      mode: PASSTHROUGH
+  - hosts:
+    - '*'
+    port:
+      name: tcp-istiod
+      number: 15012
+      protocol: TCP
+  - hosts:
+    - {{ .Values.onboarding.endpoint.host }}
+    port:
+      name: tls-onboarding-plane
+      number: 15443
+      protocol: TLS
+    tls:
+      credentialName: {{ .Values.onboarding.endpoint.tlsSecretName }}
+      mode: SIMPLE
+  - hosts:
+    - '*'
+    port:
+      name: vm-to-k8s-services
+      number: 15443
+      protocol: TLS
+    tls:
+      mode: AUTO_PASSTHROUGH
+  - hosts:
+    - {{ .Values.onboarding.endpoint.host }}
+    port:
+      name: onboarding-repository-https
+      number: 443
+      protocol: HTTPS
+    tls:
+      credentialName: {{ .Values.onboarding.endpoint.tlsSecretName }}
+      mode: SIMPLE

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/config/istiod-vs.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/config/istiod-vs.yaml
@@ -1,0 +1,32 @@
+
+{{- $component := .Values.gateway -}}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ $component.name }}-istiod
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  gateways:
+  - {{ .Release.Namespace }}/{{ $component.name }}
+  hosts:
+  - istiod.{{ .Release.Namespace }}.svc
+  tls:
+  - match:
+    - port: 15443
+      sniHosts:
+      - istiod.{{ .Release.Namespace }}.svc
+    route:
+    - destination:
+        host: istiod.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 15012
+  tcp:
+  - match:
+    - port: 15012
+    route:
+    - destination:
+        host: istiod.istio-system.svc.cluster.local
+        port:
+          number: 15012

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/config/onboarding-plane-vs.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/config/onboarding-plane-vs.yaml
@@ -1,0 +1,22 @@
+
+{{- $component := .Values.gateway -}}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ $component.name }}-onboarding-plane
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  gateways:
+  - {{ .Release.Namespace }}/{{ $component.name }}
+  hosts:
+  - {{ .Values.onboarding.endpoint.host }}
+  tcp:
+  - match:
+    - port: 15443
+    route:
+    - destination:
+        host: onboarding-plane.{{ .Release.Namespace }}.svc.cluster.local
+        port:
+          number: 8443

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/config/onboarding-repository-vs.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/config/onboarding-repository-vs.yaml
@@ -1,0 +1,19 @@
+
+{{- $component := .Values.gateway -}}
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  name: {{ $component.name }}-onboarding-repository
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  gateways:
+  - {{ .Release.Namespace }}/{{ $component.name }}
+  hosts:
+  - {{ .Values.onboarding.endpoint.host }}
+  http:
+  - name: onboarding-repository
+    route:
+    - destination:
+        host: onboarding-repository.{{ .Release.Namespace }}.svc.cluster.local

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/deployment.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/deployment.yaml
@@ -1,0 +1,90 @@
+{{- $component := .Values.gateway -}}
+{{- $kubeSpec := $component.kubeSpec -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: {{ $component.name }}
+    istio: ingressgateway
+    app.kubernetes.io/name: {{ $component.name }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: {{ $component.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  replicas: {{ $kubeSpec.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ $component.name }}
+      istio: ingressgateway
+  template:
+    metadata:
+      annotations:
+        inject.istio.io/templates: gateway
+        prometheus.io/path: /stats/prometheus
+        prometheus.io/port: "15020"
+        prometheus.io/scrape: "true"
+        sidecar.istio.io/inject: "true"
+      labels:
+        app: {{ $component.name }}
+        istio: ingressgateway
+        sidecar.istio.io/inject: "true"
+        app.kubernetes.io/name: {{ $component.name }}
+        {{- include "onboarding.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: {{ $component.name }}-service-account
+      affinity:
+{{ toYaml $kubeSpec.deployment.affinity | indent 8 }}
+      securityContext:
+{{ toYaml $kubeSpec.deployment.podSecurityContext | indent 8 }}
+      containers:
+      - env:
+        - name: ISTIO_META_ROUTER_MODE
+          # enable "AUTO_PASSTHROUGH" for vmGateway https://github.com/istio/istio/blob/master/releasenotes/notes/sni-dnat-default.yaml
+          value: sni-dnat
+        - name: ISTIO_META_UNPRIVILEGED_POD
+          # The vmGateway does not need to run as root
+          value: "true"
+        - name: ISTIO_META_REQUESTED_NETWORK_VIEW
+          # The vmGateway only needs to see the endpoints in the the kubernetes network
+          value: {{ $component.network }}
+        image: auto
+        imagePullPolicy: IfNotPresent
+        name: istio-proxy
+        ports:
+        - containerPort: 15021
+          protocol: TCP
+        - containerPort: 15443
+          protocol: TCP
+        - containerPort: 8443
+          protocol: TCP
+        - containerPort: 15012
+          protocol: TCP
+        - containerPort: 15090
+          name: http-envoy-prom
+          protocol: TCP
+        resources:
+{{ toYaml $kubeSpec.deployment.resources | indent 10 }}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/istio/ingressgateway-certs
+          name: ingressgateway-certs
+          readOnly: true
+        - mountPath: /etc/istio/ingressgateway-ca-certs
+          name: ingressgateway-ca-certs
+          readOnly: true
+      securityContext:
+        runAsGroup: 1337
+        runAsNonRoot: true
+        runAsUser: 1337
+      volumes:
+      - name: ingressgateway-certs
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: istio-ingressgateway-certs
+      - name: ingressgateway-ca-certs
+        secret:
+          defaultMode: 420
+          optional: true
+          secretName: istio-ingressgateway-ca-certs

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/role.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/role.yaml
@@ -1,0 +1,20 @@
+{{- $component := .Values.gateway -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: {{ $component.name }}
+    istio.io/rev: default
+    app.kubernetes.io/name: {{ $component.name }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: {{ $component.name }}-sds
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - secrets
+  verbs:
+  - get
+  - watch
+  - list

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/rolebinding.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/rolebinding.yaml
@@ -1,0 +1,18 @@
+{{- $component := .Values.gateway -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: {{ $component.name }}
+    istio.io/rev: default
+    app.kubernetes.io/name: {{ $component.name }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: {{ $component.name }}-sds
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ $component.name }}-sds
+subjects:
+- kind: ServiceAccount
+  name: {{ $component.name }}-service-account

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/service.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/service.yaml
@@ -1,0 +1,36 @@
+{{- $component := .Values.gateway -}}
+{{- $kubeSpec := $component.kubeSpec -}}
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: {{ $component.name }}
+    istio: ingressgateway
+    istio.io/rev: default
+    topology.istio.io/network: {{ $component.network }}
+    app.kubernetes.io/name: {{ $component.name }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: {{ $component.name }}
+  namespace: {{ .Release.Namespace }}
+spec:
+  type: LoadBalancer
+  ports:
+  - name: status-port
+    port: 15021
+    protocol: TCP
+    targetPort: 15021
+  - name: tls
+    port: 15443
+    protocol: TCP
+    targetPort: 15443
+  - name: https
+    port: 443
+    protocol: TCP
+    targetPort: 8443
+  - name: tcp-istiod
+    port: 15012
+    protocol: TCP
+    targetPort: 15012
+  selector:
+    app: {{ $component.name }}
+    istio: ingressgateway

--- a/charts/addons/onboarding-operator/templates/onboarding-gateway/serviceaccount.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-gateway/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- $image := .Values.image -}}
+{{- $component := .Values.gateway -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ $component.name }}
+    istio: ingressgateway
+    istio.io/rev: default
+    app.kubernetes.io/name: {{ $component.name }}
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: {{ $component.name }}-service-account
+  namespace: {{ .Release.Namespace }}
+{{- with $image.pullSecrets }}
+imagePullSecrets:
+{{ toYaml . }}
+{{- end }}

--- a/charts/addons/onboarding-operator/templates/onboarding-operator/deployment.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-operator/deployment.yaml
@@ -1,0 +1,76 @@
+{{- $image := .Values.image -}}
+{{- $component := .Values.operator -}}
+{{- $kubeSpec := $component.kubeSpec -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-operator
+    app.kubernetes.io/name: onboarding-operator
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  replicas: {{ $kubeSpec.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: onboarding-operator
+  template:
+    metadata:
+      labels:
+        app: onboarding-operator
+        app.kubernetes.io/name: onboarding-operator
+        {{- include "onboarding.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: onboarding-operator
+      affinity:
+{{ toYaml $kubeSpec.deployment.affinity | indent 8 }}
+      securityContext:
+{{ toYaml $kubeSpec.deployment.podSecurityContext | indent 8 }}
+
+      containers:
+      - name: onboarding-operator
+        image: {{ $image.repository }}/onboarding-operator-server:{{ $image.tag }}
+        imagePullPolicy: {{ $image.pullPolicy }}
+        args:
+        - --log-output-level
+        - {{ $component.logLevel }}
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: ONBOARDING_GATEWAY
+          value: {{ .Values.gateway.name }}.{{ .Release.Namespace }}.svc.cluster.local
+        securityContext:
+{{ toYaml $kubeSpec.deployment.containerSecurityContext | indent 10 }}
+        volumeMounts:
+        - mountPath: /tmp
+          name: tmp
+        resources:
+{{ toYaml $kubeSpec.deployment.resources | indent 10 }}
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: 9082
+          timeoutSeconds: 1
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 9082
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1
+      volumes:
+      - emptyDir: {}
+        name: tmp

--- a/charts/addons/onboarding-operator/templates/onboarding-operator/rbac.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-operator/rbac.yaml
@@ -1,0 +1,201 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  labels:
+    app: onboarding-operator
+    app.kubernetes.io/name: onboarding-operator
+    {{- include "onboarding.labels" . | nindent 4 }}
+  name: istio-system-onboarding-operator
+rules:
+- apiGroups:
+  - admissionregistration.k8s.io
+  resources:
+  - mutatingwebhookconfigurations
+  - validatingwebhookconfigurations
+  verbs:
+  - '*'
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  - certificatesigningrequests/approval
+  - certificatesigningrequests/status
+  verbs:
+  - update
+  - create
+  - get
+  - delete
+- apiGroups:
+  - certificates.k8s.io
+  resourceNames:
+  - kubernetes.io/legacy-unknown
+  resources:
+  - signers
+  verbs:
+  - approve
+  - sign
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - clusterrolebindings
+  - clusterroles
+  verbs:
+  - '*'
+- apiGroups:
+  - runtime.onboarding.tetrate.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resourceNames:
+  - csr-signer
+  resources:
+  - secrets
+  verbs:
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  labels:
+    app: onboarding-operator
+  name: istio-system-onboarding-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: istio-system-onboarding-operator
+subjects:
+- kind: ServiceAccount
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  labels:
+    app: onboarding-operator
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+rules:
+- apiGroups:
+  - ""
+  resourceNames:
+  - onboarding-operator-lock
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - update
+  - delete
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - events
+  verbs:
+  - create
+  - update
+  - patch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - create
+  - update
+- apiGroups:
+  - apps
+  - extensions
+  - batch
+  resources:
+  - daemonsets
+  - deployments
+  - deployments/finalizers
+  - ingresses
+  - replicasets
+  - statefulsets
+  - cronjobs
+  verbs:
+  - '*'
+- apiGroups:
+  - autoscaling
+  resources:
+  - horizontalpodautoscalers
+  verbs:
+  - '*'
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  verbs:
+  - '*'
+- apiGroups:
+  - networking.istio.io
+  resources:
+  - destinationrules
+  - sidecars
+  verbs:
+  - '*'
+- apiGroups:
+  - security.istio.io
+  resources:
+  - peerauthentications
+  verbs:
+  - '*'
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - endpoints
+  - events
+  - namespaces
+  - pods
+  - persistentvolumeclaims
+  - secrets
+  - services
+  - serviceaccounts
+  verbs:
+  - '*'
+- apiGroups:
+  - install.onboarding.tetrate.io
+  - authorization.onboarding.tetrate.io
+  resources:
+  - '*'
+  verbs:
+  - '*'
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  labels:
+    app: onboarding-operator
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: onboarding-operator
+subjects:
+- kind: ServiceAccount
+  name: onboarding-operator

--- a/charts/addons/onboarding-operator/templates/onboarding-operator/service.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-operator/service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-operator
+    app.kubernetes.io/name: onboarding-operator
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: webhook
+    port: 443
+    protocol: TCP
+    targetPort: 9443
+  selector:
+    app: onboarding-operator

--- a/charts/addons/onboarding-operator/templates/onboarding-operator/serviceaccount.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-operator/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- $image := .Values.image -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onboarding-operator
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-operator
+    app.kubernetes.io/name: onboarding-operator
+    {{- include "onboarding.labels" . | nindent 4 }}
+{{- with $image.pullSecrets }}
+imagePullSecrets:
+{{ toYaml . }}
+{{- end }}

--- a/charts/addons/onboarding-operator/templates/onboarding-repository/autoscale.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-repository/autoscale.yaml
@@ -1,0 +1,22 @@
+{{- $component := .Values.repository -}}
+{{- $kubeSpec := $component.kubeSpec -}}
+{{- if and $kubeSpec.deployment.hpaSpec $kubeSpec.deployment.hpaSpec.maxReplicas $kubeSpec.deployment.hpaSpec.minReplicas }}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: onboarding-repository
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-repository
+    app.kubernetes.io/name: onboarding-repository
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  maxReplicas: {{ $kubeSpec.deployment.hpaSpec.maxReplicas }}
+  minReplicas: {{ $kubeSpec.deployment.hpaSpec.minReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: onboarding-repository
+  metrics:
+{{ toYaml $kubeSpec.deployment.hpaSpec.metrics | indent 4 }}
+{{- end }}

--- a/charts/addons/onboarding-operator/templates/onboarding-repository/deployment.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-repository/deployment.yaml
@@ -1,0 +1,98 @@
+{{- $image := .Values.image -}}
+{{- $component := .Values.repository -}}
+{{- $kubeSpec := $component.kubeSpec -}}
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: onboarding-repository
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-repository
+    app.kubernetes.io/name: onboarding-repository
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  replicas: {{ $kubeSpec.deployment.replicaCount }}
+  selector:
+    matchLabels:
+      app: onboarding-repository
+  strategy:
+{{ toYaml $kubeSpec.deployment.strategy | indent 4 }}
+  template:
+    metadata:
+      labels:
+        app: onboarding-repository
+        app.kubernetes.io/name: onboarding-repository
+        {{- include "onboarding.labels" . | nindent 8 }}
+    spec:
+      serviceAccountName: onboarding-repository
+      securityContext:
+{{ toYaml $kubeSpec.deployment.podSecurityContext | indent 8 }}
+      affinity:
+{{ toYaml $kubeSpec.deployment.affinity | indent 8 }}
+      volumes:
+      # volume to copy DEB/RPM packages out of the `onboarding-package-istio-sidecar` image to
+      - name: istio-sidecar-default
+        emptyDir: {}
+{{- if .Values.istio.revisions }}
+      - name: istio-sidecar-revisions
+        emptyDir: {}
+{{- end }}
+      initContainers:
+      # copy DEB/RPM packages out of the `onboarding-package-istio-sidecar` image onto a shared volume
+      - name: istio-sidecar-default
+        image: {{ $image.repository }}/onboarding-package-istio-sidecar:{{ $component.onboardingPackageIstioSidecar.tag }}
+        command:
+        - cp
+        - -rpTv
+        - /srv/install
+        - /onboarding/repo/istio-sidecar/.default
+        volumeMounts:
+        - name: istio-sidecar-default
+          mountPath: /onboarding/repo/istio-sidecar
+{{- range $index, $revision := .Values.istio.revisions }}
+      # copy DEB/RPM packages out of the `onboarding-package-istio-sidecar` image onto a shared volume
+      - name: is-rev-{{ $revision.name }}
+        image: {{ $image.repository }}/onboarding-package-istio-sidecar:{{ $revision.version }}
+        command:
+        - cp
+        - -rpTv
+        - /srv/install
+        - /onboarding/repo/istio-sidecar/{{ $revision.name }}
+        volumeMounts:
+        - name: istio-sidecar-revisions
+          mountPath: /onboarding/repo/istio-sidecar
+{{- end }}
+      containers:
+      - name: onboarding-repository
+        image: {{ $image.repository }}/onboarding-repository-server:{{ $image.tag }}
+        imagePullPolicy: {{ $image.pullPolicy }}
+        volumeMounts:
+        - name: istio-sidecar-default
+          mountPath: /.srv/install/istio-sidecar
+{{- if .Values.istio.revisions }}
+        - name: istio-sidecar-revisions
+          mountPath: /srv/install/istio-sidecar
+{{- end }}
+        securityContext:
+{{ toYaml $kubeSpec.deployment.containerSecurityContext | indent 10 }}
+        resources:
+{{ toYaml $kubeSpec.deployment.resources | indent 10 }}
+        livenessProbe:
+          failureThreshold: 3
+          initialDelaySeconds: 1
+          periodSeconds: 5
+          successThreshold: 1
+          tcpSocket:
+            port: 9082
+          timeoutSeconds: 1
+        name: onboarding-repository
+        readinessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /health
+            port: 9082
+            scheme: HTTP
+          initialDelaySeconds: 5
+          periodSeconds: 5
+          successThreshold: 1
+          timeoutSeconds: 1

--- a/charts/addons/onboarding-operator/templates/onboarding-repository/service.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-repository/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: onboarding-repository
+  namespace: {{.Release.Namespace}}
+  labels:
+    app: onboarding-repository
+    app.kubernetes.io/name: onboarding-repository
+    {{- include "onboarding.labels" . | nindent 4 }}
+spec:
+  ports:
+  - name: http
+    port: 8080
+    targetPort: 8080
+  selector:
+    app: onboarding-repository

--- a/charts/addons/onboarding-operator/templates/onboarding-repository/serviceaccount.yaml
+++ b/charts/addons/onboarding-operator/templates/onboarding-repository/serviceaccount.yaml
@@ -1,0 +1,14 @@
+{{- $image := .Values.image -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: onboarding-repository
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: onboarding-repository
+    app.kubernetes.io/name: onboarding-repository
+    {{- include "onboarding.labels" . | nindent 4 }}
+{{- with $image.pullSecrets }}
+imagePullSecrets:
+{{ toYaml . }}
+{{- end }}

--- a/charts/addons/onboarding-operator/values.yaml
+++ b/charts/addons/onboarding-operator/values.yaml
@@ -1,0 +1,60 @@
+# Image configuration for the onboarding images.
+image:
+  # Image repository from where download the onboarding images.
+  repository:  addon-containers.istio.tetratelabs.com
+  # Onboarding image tag to be used.
+  tag:  0.1.0-onboarding-rc.1
+  # Image pull policy to be used to pull the onboarding images.
+  pullPolicy: IfNotPresent
+  # Image pull secret to be used to pull the onboarding images.
+  pullSecret: []
+
+# TODO add description for the helm chart values
+istio:
+  revisions: []
+
+onboarding:
+  endpoint:
+    host: onboarding-endpoint.example
+    tlsSecretName: onboarding-endpoint-tls-cert
+
+operator:
+  logLevel: "all:info"
+  kubeSpec:
+    deployment:
+      replicaCount: 1
+      resources:
+        limits:
+          cpu: 500m
+          memory: 512Mi
+        requests:
+          cpu: 50m
+          memory: 128Mi
+
+repository:
+  onboardingPackageIstioSidecar:
+    tag: 1.24.3-4fcf99438c
+  kubeSpec:
+    deployment:
+      replicaCount: 1
+      resources:
+        limits:
+          cpu: 100m
+          memory: 128Mi
+        requests:
+          cpu: 10m
+          memory: 32Mi
+
+gateway:
+  name: vmgateway
+  network: "kube-network"
+  kubeSpec:
+    deployment:
+      replicaCount: 1
+      resources:
+        limits:
+          cpu: "1"
+          memory: 4Gi
+        requests:
+          cpu: 500m
+          memory: 2Gi


### PR DESCRIPTION
This PR adds onboarding operator chart to the TIS addons.

The original chart is located in the [workload-onboarding-operator](https://github.com/tetrateio/worklworkload-onboarding-operator/tree/main/onboarding-helm-chart) repository.

I created this PR manually since we are scheduled to release the first version this week. Subsequent chart PRs will be created automatically using a Github workflow.