### PR TITLE
onboarding helm chart 0.1.0-rc.2

### DIFF
--- a/charts/addons/onboarding-operator/Chart.yaml
+++ b/charts/addons/onboarding-operator/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 0.1.0-rc.1
-appVersion: 0.1.0-onboarding-rc.1
+version: 0.1.0-rc.2
+appVersion: 0.1.0-onboarding-rc.2
 description: Helm chart for the Onboarding Operator
 name: onboarding-operator
 icon: https://docs.tetrate.io/logos/tetrate.svg

--- a/charts/addons/onboarding-operator/README.md
+++ b/charts/addons/onboarding-operator/README.md
@@ -1,9 +1,8 @@
 # onboarding-operator
 
-![Version: 0.1.0-rc.1](https://img.shields.io/badge/Version-0.1.0--rc.1-informational?style=flat-square)
+![Version: 0.1.0-rc.2](https://img.shields.io/badge/Version-0.1.0--rc.2-informational?style=flat-square)
 ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-![AppVersion: 0.1.0-onboarding-rc.1](https://img.shields.io/badge/AppVersion-0.1.0--onboarding--rc.1-informational?style=flat-square)
-
+![AppVersion: 0.1.0-onboarding-rc.2](https://img.shields.io/badge/AppVersion-0.1.0--onboarding--rc.2-informational?style=flat-square)
 
 Helm chart for the Workload Onboarding Operator. It is used to onboard EC2 VMs and ECS tasks to an Istio service mesh installed on an EKS cluster.
 
@@ -12,15 +11,15 @@ Helm chart for the Workload Onboarding Operator. It is used to onboard EC2 VMs a
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | image.repository | string | `"addon-containers.istio.tetratelabs.com"` | Image repository from where download the onboarding images |
-| image.tag | string | `"0.1.0-onboarding-rc.1"` | Onboarding image tag to be used |
-| image.pullSecret | list | `[]` | Image pull secret to be used to pull the onboarding images |
+| image.tag | string | `"0.1.0-onboarding-rc.2"` | Onboarding image tag to be used |
+| image.pullSecrets | list | `[]` | Image pull secrets to be used to pull the onboarding images |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
-| repository.onboardingPackageIstioSidecar.tag | string | `"1.24.3-4fcf99438c"` | Istio sidecar tag to be used for the onboarding workloads |
+| repository.onboardingPackageIstioSidecar.tag | string | `"1.24.3-tetrate3"` | Istio sidecar tag to be used for the onboarding workloads |
 | onboarding.endpoint.host | string | `"onboarding-endpoint.example"` | Hostname for the onboarding endpoint |
 | onboarding.endpoint.tlsSecretName | string | `"onboarding-endpoint-tls-cert"` | Secret name for the onboarding endpoint TLS certificate |
 
 To view all support configuration options and documentation, run:
 
 ```
-helm show values tetratelabs/onboarding-operator
+helm show values tetratelabs/onboarding-operator --devel
 ```

--- a/charts/addons/onboarding-operator/values.yaml
+++ b/charts/addons/onboarding-operator/values.yaml
@@ -3,19 +3,21 @@ image:
   # Image repository from where download the onboarding images.
   repository:  addon-containers.istio.tetratelabs.com
   # Onboarding image tag to be used.
-  tag:  0.1.0-onboarding-rc.1
+  tag:  0.1.0-onboarding-rc.2
   # Image pull policy to be used to pull the onboarding images.
   pullPolicy: IfNotPresent
-  # Image pull secret to be used to pull the onboarding images.
-  pullSecret: []
+  # Image pull secrets to be used to pull the onboarding images.
+  pullSecrets: []
 
-# TODO add description for the helm chart values
 istio:
   revisions: []
 
 onboarding:
   endpoint:
+    # Hostname of the onboarding endpoint.
     host: onboarding-endpoint.example
+    # TLS secret name to be used for the onboarding endpoint.
+    # This secret should be created in the same namespace where the onboarding operator is deployed.
     tlsSecretName: onboarding-endpoint-tls-cert
 
 operator:
@@ -33,7 +35,8 @@ operator:
 
 repository:
   onboardingPackageIstioSidecar:
-    tag: 1.24.3-4fcf99438c
+    # Sidecar version to be used in the onboarding package. This should be the same as the installed TID version.
+    tag: 1.24.3-tetrate3
   kubeSpec:
     deployment:
       replicaCount: 1
@@ -46,7 +49,9 @@ repository:
           memory: 32Mi
 
 gateway:
+  # Name of the gateway. This name will be used for the gateway service and the gateway deployment.
   name: vmgateway
+  # The network that the gateway belongs to. The VMGateway is a east-west gateway and must know about the kubernetes network to route traffic.
   network: "kube-network"
   kubeSpec:
     deployment:


### PR DESCRIPTION
Publish onboarding helm chart 0.1.0-rc.2.

This version adds supports to TID 1.24.3-tetrate0, 1.24.3-tetrate1, 1.24.3-tetrate2, 1.24.3-tetrate3